### PR TITLE
Demultiplex streams of the same resource

### DIFF
--- a/examples/browser/src/index.ts
+++ b/examples/browser/src/index.ts
@@ -54,7 +54,7 @@ async function connectToLighthouse(url: string, auth: Auth, view: HTMLCanvasElem
   logger.info('Connected!');
 
   // Register event handlers
-  const stream = lh.streamModel();
+  const stream = await lh.streamModel();
   (async () => {
     try {
       for await (const event of stream) {

--- a/examples/node/src/index.ts
+++ b/examples/node/src/index.ts
@@ -29,7 +29,7 @@ function getEnv(name: string): string {
 
   // Register input handlers
   (async () => {
-    for await (const event of lh.streamModel()) {
+    for await (const event of await lh.streamModel()) {
       const payload = event.PAYL;
       if (isInputEvent(payload)) {
         logger.info(`Got event ${JSON.stringify(payload)}`);

--- a/src/__tests__/lighthouse.test.ts
+++ b/src/__tests__/lighthouse.test.ts
@@ -53,7 +53,7 @@ test('streaming user model', async () => {
     }
   });
 
-  const payloads = (await collectAsyncIterable(lh.streamModel('test'), 4)).map(msg => msg.PAYL);
+  const payloads = (await collectAsyncIterable(await lh.streamModel('test'), 4)).map(msg => msg.PAYL);
   expect(payloads).toStrictEqual(['Message 0', 'Message 1', 'Message 2', 'Message 3']);
 });
 
@@ -69,12 +69,12 @@ test('streaming same resource multiple times', async () => {
     }
   });
 
-  const streams = [...Array(3)].map(() => lh.stream(['test-stream'])[Symbol.asyncIterator]());
+  const streams = await Promise.all([...Array(3)].map(async () => (await lh.stream(['test-stream']))[Symbol.asyncIterator]()));
 
   for (let i = 0; i < 4; i++) {
-    console.log(`Checking stream message ${i}`);
-    for (const stream of streams) {
-      const message = (await stream.next()).value;
+    for (let j = 0; j < streams.length; j++) {
+      console.log(`Checking stream message ${i}, demultiplexed to stream ${j}...`);
+      const message = (await streams[j].next()).value;
       const payload = message.PAYL;
       expect(payload).toBe(`Message ${i}`);
     }


### PR DESCRIPTION
This reduces the potential for API misuse (which currently doesn't handle the case where a resource is streamed multiple times concurrently well) by demultiplexing a single stream to the server into every logical stream (i.e. `AsyncIterable<ServerMessage<unknown>>` as returned by `Lighthouse.stream`).

Note: While out-of-order messages are demultiplexed to each registered stream, this does not account for any future streams. Every stream will only receive messages from when it's called.