### PR TITLE
Update key events to provide code and modifiers instead of key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nighthouse",
-  "version": "4.2.1",
+  "version": "5.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nighthouse",
-      "version": "4.2.1",
+      "version": "5.0.0",
       "license": "MIT",
       "workspaces": [
         "examples/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nighthouse",
-  "version": "4.2.1",
+  "version": "5.0.0",
   "description": "Lightweight Project Lighthouse client for JavaScript",
   "workspaces": [
     "examples/*"

--- a/src/common/protocol/input/new.ts
+++ b/src/common/protocol/input/new.ts
@@ -10,8 +10,18 @@ interface BaseInputEvent<Type extends string> {
 export interface KeyEvent extends BaseInputEvent<'key'> {
   /** Whether the key was pressed. */
   down: boolean;
-  /** The key pressed, see the docs on JS's `KeyboardEvent.key` for a description. */
-  key: string;
+  /** Whether the event is a repeat event. */
+  repeat: boolean;
+  /** The key pressed, see the docs on JS's `KeyboardEvent.code` for a description. */
+  code: string;
+  /** Whether the alt key is held. */
+  altKey: boolean;
+  /** Whether the ctrl key is held. */
+  ctrlKey: boolean;
+  /** Whether the meta key is held. */
+  metaKey: boolean;
+  /** Whether the shiftKey key is held. */
+  shiftKey: boolean;
 }
 
 /** A mouse event payload. */


### PR DESCRIPTION
This provides a more precise mapping to clients, which is useful e.g. for games that want to handle WASD keys in a uniform way independent on modifiers, which currently would generally capitalized/non-capitalized key values.

This is a breaking change that requires updating the clients accordingly.